### PR TITLE
dao_id required for prompt / mission.

### DIFF
--- a/lib/images.py
+++ b/lib/images.py
@@ -38,7 +38,7 @@ def generate_token_image(name: str, symbol: str, description: str) -> bytes:
     Args:
         name: Token name
         symbol: Token symbol
-        description: Token description
+        description: DAO mission used for image generation context
 
     Returns:
         bytes: The image content in bytes
@@ -46,7 +46,7 @@ def generate_token_image(name: str, symbol: str, description: str) -> bytes:
     Raises:
         ImageGenerationError: If image generation fails
     """
-    prompt = f"Draw from iconic, yet not overplayed references (Bauhaus geometry, Swiss minimalism, NASA mission patches, mid-century graphics, Apples refined approach, and subtle 80s neon). Synthesize or pick styles based on {description} to create a bold, circular icon for {name}, featuring {symbol}. Keep it minimal, high-contrast, and recognizable at small sizes. Avoid clutter, extraneous text, or clichés. Aim for a universal, timeless, visually striking design."
+    prompt = f"Create a single, bold circular icon for {name}, featuring {symbol} in a minimal geometric style that reflects the DAO’s mission: {description}. Use only these colors: • Orange #FF4F03 • Electric Blue #0533D1 • Black #000000 • White #FFFFFF • Grey #58595B • Orange→Blue gradient (sparingly) Keep lines clean, shapes few, and contrast high for immediate recognition, drawing from Swiss minimalism or NASA-inspired design."
     try:
         image_url = generate_image(prompt)
         if not image_url:

--- a/lib/token_assets.py
+++ b/lib/token_assets.py
@@ -33,6 +33,7 @@ class TokenMetadata:
     description: str
     decimals: int
     max_supply: str
+    dao_mission: str
     image_url: Optional[str] = None
     uri: Optional[str] = None
 
@@ -56,7 +57,7 @@ class TokenAssetManager:
             image_bytes = generate_token_image(
                 name=metadata.name,
                 symbol=metadata.symbol,
-                description=metadata.description,
+                description=metadata.dao_mission,  # Always use dao_mission
             )
 
             if not isinstance(image_bytes, bytes):

--- a/services/types.py
+++ b/services/types.py
@@ -1,0 +1,46 @@
+from enum import Enum
+from pydantic import BaseModel
+from typing import Any, Dict, Optional
+
+class TweetType(str, Enum):
+    TOOL_REQUEST = "tool_request"
+    CONVERSATION = "thread"
+    INVALID = "invalid"
+
+class ToolRequest(BaseModel):
+    tool_name: str
+    parameters: Dict[str, Any]
+    priority: int = 1
+
+class TweetAnalysisOutput(BaseModel):
+    worthy: bool
+    reason: str
+    tweet_type: TweetType
+    tool_request: Optional[ToolRequest] = None
+    confidence_score: float
+
+class TweetResponseOutput(BaseModel):
+    response: str
+    tone: str
+    hashtags: list[str]
+    mentions: list[str]
+    urls: list[str]
+
+class ToolResponseOutput(BaseModel):
+    success: bool
+    status: str
+    message: str
+    details: Dict[str, Any]
+    input_parameters: Dict[str, Any]
+
+class TweetAnalysisState(BaseModel):
+    is_worthy: bool = False
+    tweet_type: TweetType = TweetType.INVALID
+    tool_request: Optional[ToolRequest] = None
+    response_required: bool = False
+    tweet_text: str = ""
+    filtered_content: str = ""
+    analysis_complete: bool = False
+    tool_result: Optional[str] = None
+    response: Optional[TweetResponseOutput] = None
+    tool_success: bool = False


### PR DESCRIPTION
Token creation requires a DAO ID
System validates DAO exists and has a mission upfront
If validation fails, token creation is aborted
If validation passes, mission is guaranteed to be available
Image generation always uses the DAO mission
This ensures that:

Every token must be associated with a DAO
Every DAO must have a mission
No fallback logic needed since we validate upfront
Clearer error messages if requirements not met