### PR TITLE
Handle long tweets via threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ aibtcdev-backend/
 
 ### 3. Social Media Integration
 - Twitter automation and monitoring
+- Tweets longer than 280 characters are automatically threaded
 - Telegram bot integration
 - Discord notifications
 - Automated content generation


### PR DESCRIPTION
## Summary
- introduce `_split_text_into_chunks` helper for TweetTask
- send long tweets as threaded posts
- document that long tweets are split into threads

## Testing
- `ruff format services/runner/tasks/tweet_task.py`
- `ruff check services/runner/tasks/tweet_task.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*