### PR TITLE
auto approve AIBTC-BREW

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -277,6 +277,13 @@ class NetworkConfig:
 
 
 @dataclass
+class AutoVotingApprovalConfig:
+    enabled: bool = (
+        os.getenv("AIBTC_AUTO_VOTING_APPROVAL_ENABLED", "false").lower() == "true"
+    )
+
+
+@dataclass
 class Config:
     db: DatabaseConfig = field(default_factory=DatabaseConfig)
     twitter: TwitterConfig = field(default_factory=TwitterConfig)
@@ -292,6 +299,9 @@ class Config:
     chat_llm: ChatLLMConfig = field(default_factory=ChatLLMConfig)
     embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
     huggingface: HuggingFaceConfig = field(default_factory=HuggingFaceConfig)
+    auto_voting_approval: AutoVotingApprovalConfig = field(
+        default_factory=AutoVotingApprovalConfig
+    )
 
     @classmethod
     def load(cls) -> "Config":

--- a/app/services/infrastructure/job_management/tasks/agent_account_deployer.py
+++ b/app/services/infrastructure/job_management/tasks/agent_account_deployer.py
@@ -498,7 +498,10 @@ class AgentAccountDeployerTask(BaseTask[AgentAccountDeployResult]):
                                     )
 
                                     # 2025/10 ADDED TO SUPPORT AIBTC-BREW
-                                    if config.network.network == "testnet":
+                                    if (
+                                        config.auto_voting_approval.enabled
+                                        and config.network.network == "testnet"
+                                    ):
                                         await self._approve_aibtc_brew_contract(
                                             wallet, full_contract_principal
                                         )


### PR DESCRIPTION
we removed the buy modal
we set the bond to 0 (open contributions)
agent voting accounts still require contract to be approved

we were handling that when they bought a DAO's token automatically

this makes it so we automatically approve AIBTC-BREW voting contract right after deployment

also ties feature to feature flag in env `AIBTC_AUTO_VOTING_APPROVAL_ENABLED = "true"`