### PR TITLE
Fix ts tool parsing 2

### DIFF
--- a/app/tools/bun.py
+++ b/app/tools/bun.py
@@ -153,7 +153,7 @@ class BunScriptRunner:
                 extra={"return_code": e.returncode, "stderr": error_output},
             )
             return {
-                "output": stdout_output,
+                "output": stdout_output or "",
                 "error": error_output,
                 "success": False,
             }


### PR DESCRIPTION
When TS hits an error it catches it and returns it in a consistent ToolResponse format and exits with status 1.

In Python we see the exit status and immediately say Python failed but that's incorrect.

Now if we see the subprocess exit we try to parse error info from the TS tool and rely on the `ts_success` value for outcome instead.

General python errors or unexpected occurrences will still fail the Python result like before.