### PR TITLE
safe int conversion in lottery

### DIFF
--- a/app/services/integrations/webhooks/chainhook/handlers/action_proposal_handler.py
+++ b/app/services/integrations/webhooks/chainhook/handlers/action_proposal_handler.py
@@ -412,7 +412,9 @@ class ActionProposalHandler(BaseProposalHandler):
         try:
             return int(float(value.strip()))
         except (ValueError, TypeError) as e:
-            self.logger.warning(f"Failed to parse '{value}' as int: {e}, defaulting to 0")
+            self.logger.warning(
+                f"Failed to parse '{value}' as int: {e}, defaulting to 0"
+            )
             return 0
 
     def _get_agent_token_holders(self, dao_id: UUID) -> List[AgentWithWalletTokenDTO]:

--- a/app/services/integrations/webhooks/chainhook/handlers/lottery_utils.py
+++ b/app/services/integrations/webhooks/chainhook/handlers/lottery_utils.py
@@ -56,66 +56,8 @@ class QuorumCalculator:
             logger.error(f"Error calculating total eligible tokens: {e}")
             return "0"
 
-    @staticmethod
-    def is_quorum_achievable(
-        liquid_tokens: str, total_eligible_tokens: str, quorum_percentage: float = 0.15
-    ) -> bool:
-        """Check if quorum is achievable with available tokens.
 
-        Args:
-            liquid_tokens: Total liquid supply
-            total_eligible_tokens: Total tokens held by eligible agents
-            quorum_percentage: Required quorum percentage
 
-        Returns:
-            True if quorum is achievable, False otherwise
-        """
-        try:
-            quorum_threshold = QuorumCalculator.calculate_quorum_threshold(
-                liquid_tokens, quorum_percentage
-            )
-            return Decimal(total_eligible_tokens) >= Decimal(quorum_threshold)
-        except (ValueError, TypeError) as e:
-            logger.error(f"Error checking quorum achievability: {e}")
-            return False
-
-    @staticmethod
-    def calculate_selected_tokens_total(selected_wallets: List[Dict[str, str]]) -> str:
-        """Calculate total tokens from selected wallets.
-
-        Args:
-            selected_wallets: List of {"wallet_id": str, "token_amount": str} dicts
-
-        Returns:
-            Total selected tokens as string
-        """
-        try:
-            total = Decimal("0")
-            for wallet in selected_wallets:
-                total += Decimal(wallet.get("token_amount", "0"))
-            return str(total)
-        except (ValueError, TypeError) as e:
-            logger.error(f"Error calculating selected tokens total: {e}")
-            return "0"
-
-    @staticmethod
-    def validate_quorum_achievement(
-        selected_tokens_total: str, quorum_threshold: str
-    ) -> bool:
-        """Check if selected tokens meet the quorum threshold.
-
-        Args:
-            selected_tokens_total: Total tokens from selected wallets
-            quorum_threshold: Required threshold to meet quorum
-
-        Returns:
-            True if quorum is achieved, False otherwise
-        """
-        try:
-            return Decimal(selected_tokens_total) >= Decimal(quorum_threshold)
-        except (ValueError, TypeError) as e:
-            logger.error(f"Error validating quorum achievement: {e}")
-            return False
 
 
 class LotterySelection:

--- a/app/services/integrations/webhooks/chainhook/handlers/lottery_utils.py
+++ b/app/services/integrations/webhooks/chainhook/handlers/lottery_utils.py
@@ -57,9 +57,6 @@ class QuorumCalculator:
             return "0"
 
 
-
-
-
 class LotterySelection:
     """Data class to hold lottery selection results."""
 


### PR DESCRIPTION
Contributions 107, 89, 86, 76, 74, 73, 69 did not have votes.

Narrowed it down to an agent with a token balance as decimal instead of int:

<img width="1600" height="414" alt="image" src="https://github.com/user-attachments/assets/517ea0c6-81d8-4d5f-a1b4-b66a068840b1" />

Updated lottery to use a `_to_safe_int` conversion that will always return a value and correctly handle the floats if necessary.