### PR TITLE
adjust rate limiting per job type

### DIFF
--- a/app/services/communication/twitter_service.py
+++ b/app/services/communication/twitter_service.py
@@ -147,6 +147,9 @@ class TwitterService:
 
             return None
 
+        except tweepy.TooManyRequests as e:
+            logger.error(f"Failed to post tweet with media: 429 Too Many Requests - {str(e)}")
+            raise
         except Exception as e:
             logger.error(f"Failed to post tweet with media: {str(e)}")
             return None
@@ -256,6 +259,9 @@ class TwitterService:
                 logger.error(f"Failed to post tweet: {text[:20]}...")
                 return None
 
+        except tweepy.TooManyRequests as e:
+            logger.error(f"Failed to post tweet: 429 Too Many Requests - {str(e)}")
+            raise
         except Exception as e:
             logger.error(f"Failed to post tweet: {str(e)}")
             return None

--- a/app/services/communication/twitter_service.py
+++ b/app/services/communication/twitter_service.py
@@ -148,7 +148,9 @@ class TwitterService:
             return None
 
         except tweepy.TooManyRequests as e:
-            logger.error(f"Failed to post tweet with media: 429 Too Many Requests - {str(e)}")
+            logger.error(
+                f"Failed to post tweet with media: 429 Too Many Requests - {str(e)}"
+            )
             raise
         except Exception as e:
             logger.error(f"Failed to post tweet with media: {str(e)}")

--- a/app/services/infrastructure/job_management/tasks/tweet_task.py
+++ b/app/services/infrastructure/job_management/tasks/tweet_task.py
@@ -530,10 +530,11 @@ class TweetTask(BaseTask[TweetProcessingResult]):
         wait_until = datetime.now(timezone.utc) + timedelta(
             seconds=retry_after + jitter
         )
+        reason = f"twitter-429 (Retry-After: {retry_after}s)"
         backend.upsert_job_cooldown(
             job_type="tweet",
             wait_until=wait_until,
-            reason=f"twitter-429 (Retry-After: {retry_after}s)",
+            reason=reason or "twitter rate limit",
         )
         self._rate_limited_this_run = True
         logger.warning(f"Tweet job rate limited; cooldown set until {wait_until}; stopping batch")

--- a/app/services/infrastructure/job_management/tasks/tweet_task.py
+++ b/app/services/infrastructure/job_management/tasks/tweet_task.py
@@ -603,7 +603,11 @@ class TweetTask(BaseTask[TweetProcessingResult]):
             except tweepy.TooManyRequests as e:
                 retry_after = 900  # Default 15min
                 try:
-                    if hasattr(e, 'response') and e.response and hasattr(e.response, 'headers'):
+                    if (
+                        hasattr(e, "response")
+                        and e.response
+                        and hasattr(e.response, "headers")
+                    ):
                         retry_after = int(e.response.headers.get("Retry-After", 900))
                 except (AttributeError, KeyError, ValueError, TypeError):
                     pass  # Use default

--- a/app/services/infrastructure/job_management/tasks/tweet_task.py
+++ b/app/services/infrastructure/job_management/tasks/tweet_task.py
@@ -537,7 +537,9 @@ class TweetTask(BaseTask[TweetProcessingResult]):
             reason=reason or "twitter rate limit",
         )
         self._rate_limited_this_run = True
-        logger.warning(f"Tweet job rate limited; cooldown set until {wait_until}; stopping batch")
+        logger.warning(
+            f"Tweet job rate limited; cooldown set until {wait_until}; stopping batch"
+        )
         return {
             "tweets_sent_this_run": tweets_sent_this_run,
             "final_tweet_id": previous_tweet_id,

--- a/app/services/infrastructure/job_management/tasks/tweet_task.py
+++ b/app/services/infrastructure/job_management/tasks/tweet_task.py
@@ -609,7 +609,7 @@ class TweetTask(BaseTask[TweetProcessingResult]):
                         and hasattr(e.response, "headers")
                     ):
                         retry_after = int(e.response.headers.get("Retry-After", 900))
-                except (AttributeError, KeyError, ValueError, TypeError):
+                except (AttributeError, ValueError, TypeError):
                     pass  # Use default
                 jitter = random.uniform(0, 30)  # Additive jitter: 0-30 seconds
                 wait_until = datetime.now(timezone.utc) + timedelta(

--- a/app/services/infrastructure/job_management/tasks/tweet_task.py
+++ b/app/services/infrastructure/job_management/tasks/tweet_task.py
@@ -631,12 +631,11 @@ class TweetTask(BaseTask[TweetProcessingResult]):
             except tweepy.TooManyRequests as e:
                 retry_after = 900  # Default 15min
                 try:
-                    if (
-                        hasattr(e, "response")
-                        and e.response
-                        and hasattr(e.response, "headers")
-                    ):
-                        retry_after = int(e.response.headers.get("Retry-After", 900))
+                    if hasattr(e, "response") and e.response:
+                        headers = getattr(e.response, "headers", {})
+                        retry_after_str = headers.get("Retry-After")
+                        if retry_after_str:
+                            retry_after = int(retry_after_str)
                 except (AttributeError, ValueError, TypeError):
                     pass  # Use default
                 return self._handle_rate_limit(

--- a/app/services/infrastructure/job_management/tasks/tweet_task.py
+++ b/app/services/infrastructure/job_management/tasks/tweet_task.py
@@ -510,7 +510,9 @@ class TweetTask(BaseTask[TweetProcessingResult]):
     ) -> Dict[str, Any]:
         """Shared rate limit handling: cooldown + early return."""
         jitter = random.uniform(0, 30)
-        wait_until = datetime.now(timezone.utc) + timedelta(seconds=retry_after + jitter)
+        wait_until = datetime.now(timezone.utc) + timedelta(
+            seconds=retry_after + jitter
+        )
         backend.upsert_job_cooldown(
             job_type="tweet",
             wait_until=wait_until,

--- a/app/services/infrastructure/job_management/tasks/tweet_task.py
+++ b/app/services/infrastructure/job_management/tasks/tweet_task.py
@@ -518,9 +518,8 @@ class TweetTask(BaseTask[TweetProcessingResult]):
             wait_until=wait_until,
             reason=f"twitter-429 (Retry-After: {retry_after}s)",
         )
-        logger.warning(f"Tweet job cooldown set until {wait_until}")
         self._rate_limited_this_run = True
-        logger.warning(f"Tweet rate limited; cooldown={wait_until}; stopping batch")
+        logger.warning(f"Tweet job rate limited; cooldown set until {wait_until}; stopping batch")
         return {
             "tweets_sent_this_run": tweets_sent_this_run,
             "final_tweet_id": previous_tweet_id,


### PR DESCRIPTION
improves how we handle the error + upserts the info so we actually enable the rate limit