### PR TITLE
fix incorrect model def

### DIFF
--- a/app/backend/models.py
+++ b/app/backend/models.py
@@ -1094,5 +1094,4 @@ class JobCooldownBase(CustomBaseModel):
 
 class JobCooldown(JobCooldownBase):
     id: UUID
-    created_at: datetime
     updated_at: Optional[datetime] = None

--- a/app/services/infrastructure/job_management/tasks/tweet_task.py
+++ b/app/services/infrastructure/job_management/tasks/tweet_task.py
@@ -140,6 +140,7 @@ class TweetTask(BaseTask[TweetProcessingResult]):
                 client_secret=config.twitter.client_secret,
                 access_token=config.twitter.access_token,
                 access_secret=config.twitter.access_secret,
+                bearer_token=config.twitter.bearer_token,
             )
             await self.twitter_service._ainitialize()
             logger.debug(f"Initialized Twitter service for DAO {dao_id}")


### PR DESCRIPTION
somehow `created_at` snuck in there

`*cough*`*hallucination*`*cough*`

also passes a missing config value to TwitterService