### PR TITLE
fix: vote REJECT when evaluation returns None (fixes #625)

### DIFF
--- a/app/services/infrastructure/job_management/tasks/dao_proposal_evaluation.py
+++ b/app/services/infrastructure/job_management/tasks/dao_proposal_evaluation.py
@@ -353,21 +353,22 @@ class DAOProposalEvaluationTask(BaseTask[DAOProposalEvaluationResult]):
             )
 
             if evaluation_output is None:
-                error_msg = f"Evaluation failed for proposal {proposal_id}"
-                logger.error(
-                    "Evaluation returned None (v2)",
+                logger.warning(
+                    "Evaluation returned None (v2) — defaulting to REJECT vote",
                     extra={
                         "proposal_id": str(proposal_id),
                     },
                 )
-                return {"success": False, "error": error_msg}
+                evaluation_data = {}
+                decision_str = "REJECT"
+                approval = False
+            else:
+                # Map EvaluationOutput to legacy structures
+                evaluation_data = evaluation_output.model_dump()
 
-            # Map EvaluationOutput to legacy structures
-            evaluation_data = evaluation_output.model_dump()
-
-            # Map decision ("APPROVE"/"REJECT") to boolean
-            decision_str = evaluation_data.get("decision", "REJECT")
-            approval = decision_str == "APPROVE"
+                # Map decision ("APPROVE"/"REJECT") to boolean
+                decision_str = evaluation_data.get("decision", "REJECT")
+                approval = decision_str == "APPROVE"
 
             overall_score = evaluation_data.get("final_score", 0)
             confidence = evaluation_data.get("confidence", 0.0)


### PR DESCRIPTION
## Summary

Fixes #625 — when DAO proposal evaluation returns `None`, the agent now votes **REJECT** instead of silently abstaining.

- **Before:** `evaluate_proposal_strict()` returns `None` → `return {"success": False, "error": ...}` → no vote record created (agent effectively abstains)
- **After:** `evaluate_proposal_strict()` returns `None` → log warning → set `evaluation_data = {}`, `decision_str = "REJECT"`, `approval = False` → proceed to create REJECT vote record

Also initialises `evaluation_data` to `{}` so all subsequent `.get()` calls on lines 373–408 remain safe when `evaluation_output is None`.

## Why

Abstaining on a failed evaluation is indistinguishable from the agent not participating at all. Voting REJECT makes the failure explicit, keeps the agent's on-chain vote count accurate, and ensures governance quorum is not silently undermined by evaluation errors.

closes #625

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)