### PR TITLE
fix(logging): log response headers on 429 rate limit responses (closes #515)

### DIFF
--- a/app/services/ai/simple_workflows/evaluation_openrouter_v2.py
+++ b/app/services/ai/simple_workflows/evaluation_openrouter_v2.py
@@ -188,9 +188,11 @@ async def call_openrouter(
         )
         if response.status_code == 429:
             logger.warning(
-                "OpenRouter rate limit exceeded",
+                "429 Too Many Requests from OpenRouter",
                 extra={
                     "status_code": response.status_code,
+                    "endpoint": f"{config_data['base_url']}/chat/completions",
+                    "response_headers": dict(response.headers),
                     "response_text": response.text,
                 },
             )

--- a/app/services/communication/twitter_service.py
+++ b/app/services/communication/twitter_service.py
@@ -148,8 +148,16 @@ class TwitterService:
             return None
 
         except tweepy.TooManyRequests as e:
-            logger.error(
-                f"Failed to post tweet with media: 429 Too Many Requests - {str(e)}"
+            response_headers = {}
+            if hasattr(e, "response") and e.response is not None:
+                response_headers = dict(e.response.headers)
+            logger.warning(
+                "429 Too Many Requests from Twitter (post_tweet_with_media)",
+                extra={
+                    "status_code": 429,
+                    "response_headers": response_headers,
+                    "error": str(e),
+                },
             )
             raise
         except Exception as e:
@@ -262,7 +270,17 @@ class TwitterService:
                 return None
 
         except tweepy.TooManyRequests as e:
-            logger.error(f"Failed to post tweet: 429 Too Many Requests - {str(e)}")
+            response_headers = {}
+            if hasattr(e, "response") and e.response is not None:
+                response_headers = dict(e.response.headers)
+            logger.warning(
+                "429 Too Many Requests from Twitter (post_tweet)",
+                extra={
+                    "status_code": 429,
+                    "response_headers": response_headers,
+                    "error": str(e),
+                },
+            )
             raise
         except Exception as e:
             logger.error(f"Failed to post tweet: {str(e)}")

--- a/app/services/infrastructure/job_management/tasks/tweet_task.py
+++ b/app/services/infrastructure/job_management/tasks/tweet_task.py
@@ -716,7 +716,17 @@ class TweetTask(BaseTask[TweetProcessingResult]):
             import tweepy
 
             if isinstance(error, tweepy.TooManyRequests):
-                logger.warning("Twitter API rate limit reached, will retry later")
+                response_headers = {}
+                if hasattr(error, "response") and error.response is not None:
+                    response_headers = dict(error.response.headers)
+                logger.warning(
+                    "429 Too Many Requests from Twitter API, will retry later",
+                    extra={
+                        "status_code": 429,
+                        "response_headers": response_headers,
+                        "error": str(error),
+                    },
+                )
                 return None  # Let default retry handling take over
 
             if isinstance(error, tweepy.ServiceUnavailable):

--- a/app/services/integrations/hiro/base.py
+++ b/app/services/integrations/hiro/base.py
@@ -253,11 +253,14 @@ class BaseHiroApi:
             return response.json()
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 429:
-                logger.error(
-                    "API rate limit exceeded",
+                logger.warning(
+                    "429 Too Many Requests from Hiro API",
                     extra={
                         "request": {"method": method, "endpoint": endpoint},
-                        "response": {"status_code": e.response.status_code},
+                        "response": {
+                            "status_code": e.response.status_code,
+                            "headers": dict(e.response.headers),
+                        },
                         "error": str(e),
                     },
                 )
@@ -332,11 +335,14 @@ class BaseHiroApi:
                 return await response.json()
         except aiohttp.ClientError as e:
             if isinstance(e, aiohttp.ClientResponseError) and e.status == 429:
-                logger.error(
-                    "Async API rate limit exceeded",
+                logger.warning(
+                    "429 Too Many Requests from Hiro API (async)",
                     extra={
                         "request": {"method": method, "endpoint": endpoint},
-                        "response": {"status_code": e.status},
+                        "response": {
+                            "status_code": e.status,
+                            "headers": dict(e.headers) if e.headers else {},
+                        },
                         "error": str(e),
                     },
                 )

--- a/app/services/processing/stacks_chainhook_adapter/client.py
+++ b/app/services/processing/stacks_chainhook_adapter/client.py
@@ -106,7 +106,16 @@ class StacksAPIClient:
                         ) from e
 
                     if e.response.status_code == 429:
-                        # Rate limited - use exponential backoff
+                        # Rate limited - log headers for diagnosis then use exponential backoff
+                        self.logger.warning(
+                            "429 Too Many Requests from Stacks API",
+                            extra={
+                                "endpoint": path,
+                                "response_headers": dict(e.response.headers),
+                                "attempt": attempt + 1,
+                                "max_retries": self.config.max_retries + 1,
+                            },
+                        )
                         if attempt < self.config.max_retries:
                             sleep_time = self._calculate_backoff(attempt)
                             self.logger.warning(


### PR DESCRIPTION
## Summary
- Adds `logger.warn()` with response headers whenever a 429 is encountered from external APIs
- Helps distinguish rate-limit-too-fast (retry-after headers) from monthly quota exhaustion (x-ratelimit-remaining etc.)
- No behavior change — pure observability improvement

## Changes

- **`app/services/communication/twitter_service.py`** — `post_tweet_with_media` and `post_tweet`: changed `tweepy.TooManyRequests` handler from `logger.error` to `logger.warning` with `response_headers` in `extra`
- **`app/services/ai/simple_workflows/evaluation_openrouter_v2.py`** — 429 branch: added `response_headers` and `endpoint` to existing `logger.warning` call
- **`app/services/integrations/hiro/base.py`** — sync `_make_request` and async `_amake_request`: changed `logger.error` to `logger.warning`, added `headers` dict to `response` extra field
- **`app/services/processing/stacks_chainhook_adapter/client.py`** — 429 retry branch: added upfront `logger.warning` with `response_headers` before the retry/exhaustion logic
- **`app/services/infrastructure/job_management/tasks/tweet_task.py`** — `_handle_execution_error`: expanded `logger.warning` to include `response_headers` and `error` in `extra`

## Test plan
- [ ] 429 response from X API → headers logged as warning
- [ ] 429 response from OpenRouter → headers logged as warning
- [ ] 429 response from Hiro API (sync and async) → headers logged as warning
- [ ] 429 response from Stacks API → headers logged as warning
- [ ] Non-429 responses → no change in behavior

🤖 T-FI autonomous agent — closes #515